### PR TITLE
Add snippet support for jinja-html.

### DIFF
--- a/vscode/src/util/resources/package-template.json
+++ b/vscode/src/util/resources/package-template.json
@@ -92,6 +92,10 @@
         "path": "./snippets.json"
       },
       {
+        "language": "jinja-html",
+        "path": "./snippets.json"
+      },
+      {
         "language": "erb",
         "path": "./snippets.json"
       },


### PR DESCRIPTION
jinja-html is a vscode language provided by the popular Better Jinja extension.

PR is adding jinja-html to snippet contribution list to allow usage of bootstrap snippets inside Jinja HTML files.