### PR TITLE
Fix some issues with bootstrap modals

### DIFF
--- a/snippets/bootstrap/components/modal/customize.html
+++ b/snippets/bootstrap/components/modal/customize.html
@@ -1,18 +1,18 @@
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#${2:modelId}">
-  ${1:Launch}
+<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#${2:modalId}">
+  	${1:Launch}
 </button>
 
 <!-- Modal -->
-<div class="modal fade" id="${2:modelId}" tabindex="-1" role="dialog" aria-labelledby="${4:modelTitleId}" aria-hidden="true">
+<div class="modal fade" id="${2:modalId}" tabindex="-1" role="dialog" aria-labelledby="${4:modalTitleId}" aria-hidden="true">
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
-				<div class="modal-header">
-						<h5 class="modal-title">${3:Modal title}</h5>
-							<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-								<span aria-hidden="true">&times;</span>
-							</button>
-					</div>
+			<div class="modal-header">
+				<h5 class="modal-title" id="${4:modalTitleId}">${3:Modal title}</h5>
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
+			</div>
 			<div class="modal-body">
 				<div class="container-fluid">
 					${7:Add rows here}
@@ -27,7 +27,7 @@
 </div>
 
 <script>
-	$('#exampleModal').on('show.bs.modal', event => {
+	$('#${2:modalId}').on('show.bs.modal', event => {
 		var button = $(event.relatedTarget);
 		var modal = $(this);
 		// Use above variables to manipulate the DOM

--- a/snippets/bootstrap/components/modal/default.html
+++ b/snippets/bootstrap/components/modal/default.html
@@ -1,17 +1,17 @@
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#${2:modelId}">
-  ${1:Launch}
+<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#${2:modalId}">
+  	${1:Launch}
 </button>
 
 <!-- Modal -->
-<div class="modal fade" id="${2:modelId}" tabindex="-1" role="dialog" aria-labelledby="${4:modelTitleId}" aria-hidden="true">
+<div class="modal fade" id="${2:modalId}" tabindex="-1" role="dialog" aria-labelledby="${4:modalTitleId}" aria-hidden="true">
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
-				<h5 class="modal-title">${3:Modal title}</h5>
-					<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-						<span aria-hidden="true">&times;</span>
-					</button>
+				<h5 class="modal-title" id="${4:modalTitleId}">${3:Modal title}</h5>
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
 			</div>
 			<div class="modal-body">
 				${7:Body}

--- a/snippets/bootstrap/components/modal/grid.html
+++ b/snippets/bootstrap/components/modal/grid.html
@@ -1,18 +1,18 @@
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#${2:modelId}">
-  ${1:Launch}
+<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#${2:modalId}">
+  	${1:Launch}
 </button>
 
 <!-- Modal -->
-<div class="modal fade" id="${2:modelId}" tabindex="-1" role="dialog" aria-labelledby="${4:modelTitleId}" aria-hidden="true">
+<div class="modal fade" id="${2:modalId}" tabindex="-1" role="dialog" aria-labelledby="${4:modalTitleId}" aria-hidden="true">
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">
-				<div class="modal-header">
-						<h5 class="modal-title">${3:Modal title}</h5>
-							<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-								<span aria-hidden="true">&times;</span>
-							</button>
-					</div>
+			<div class="modal-header">
+				<h5 class="modal-title" id="${4:modalTitleId}">${3:Modal title}</h5>
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
+			</div>
 			<div class="modal-body">
 				<div class="container-fluid">
 					${7:Add rows here}

--- a/snippets/bootstrap/components/modal/sizes.html
+++ b/snippets/bootstrap/components/modal/sizes.html
@@ -1,17 +1,17 @@
 <!-- Button trigger modal -->
-<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#${2:modelId}">
-  ${1:Launch}
+<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#${2:modalId}">
+  	${1:Launch}
 </button>
 
 <!-- Modal -->
-<div class="modal fade" id="${2:modelId}" tabindex="-1" role="dialog" aria-labelledby="${5:modelTitleId}" aria-hidden="true">
-	<div class="modal-dialog modal-${3:sm|lg}" role="document">
+<div class="modal fade" id="${2:modalId}" tabindex="-1" role="dialog" aria-labelledby="${4:modalTitleId}" aria-hidden="true">
+	<div class="modal-dialog modal-${5:sm|lg}" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
-				<h5 class="modal-title">${3:Modal title}</h5>
-					<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-						<span aria-hidden="true">&times;</span>
-					</button>
+				<h5 class="modal-title" id="${4:modalTitleId}">${3:Modal title}</h5>
+				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+					<span aria-hidden="true">&times;</span>
+				</button>
 			</div>
 			<div class="modal-body">
 				${8:Body}


### PR DESCRIPTION
This PR contains the following changes for bootstrap modals:
- variable names are consistently `modal*` now
- added `modalTitleId` as id to the modal title (`h5`)
- use modal id variable instead of "exampleModal"
- indentation uses 4 spaces everywhere
- deleted some indentations that were wrong

Thank you for this code addon. I hope this PR is deemed useful. After all I stumbled upon these issues when using it.