### PR TITLE
fix overflowing css class names of b4-button-block

### DIFF
--- a/snippets/bootstrap/components/button/block.html
+++ b/snippets/bootstrap/components/button/block.html
@@ -1,1 +1,1 @@
-<button type="button" name="$3" id="$3" class="btn btn-${2:primary|secondary|success|danger|warning|info|light|dark|link}" btn-lg btn-block">$1</button>
+<button type="button" name="$3" id="$3" class="btn btn-${2:primary|secondary|success|danger|warning|info|light|dark|link} btn-lg btn-block">$1</button>


### PR DESCRIPTION
Fixes https://github.com/1tontech/bootstrap4-snippets/issues/17