### PR TITLE
Fixed CSS overflowing class names

### DIFF
--- a/snippets/bootstrap/components/button/block.html
+++ b/snippets/bootstrap/components/button/block.html
@@ -1,1 +1,1 @@
-<button type="button" name="$3" id="$3" class="btn btn-${2:primary|secondary|success|danger|warning|info|light|dark|link}" btn-lg btn-block">$1</button>
+<button type="button" name="$3" id="$3" class="btn btn-${2:primary|secondary|success|danger|warning|info|light|dark|link} btn-lg btn-block">$1</button>


### PR DESCRIPTION
@thekalinga 
This PR fixes the extra double-quotes issues (#17 and #26). 
When using the b4-button-block an extra set of double-quotes is added before btn-lg btn-block causing it to not format those final two class names. This PR removes those double-quotes.