### PR TITLE
Removing the redundant ( " ) from the class attribute

### DIFF
--- a/snippets/bootstrap/components/button/block.html
+++ b/snippets/bootstrap/components/button/block.html
@@ -1,1 +1,1 @@
-<button type="button" name="$3" id="$3" class="btn btn-${2:primary|secondary|success|danger|warning|info|light|dark|link}" btn-lg btn-block">$1</button>
+<button type="button" name="$3" id="$3" class="btn btn-${2:primary|secondary|success|danger|warning|info|light|dark|link} btn-lg btn-block">$1</button>


### PR DESCRIPTION
After removing the redundant _"_ the **Block-Button** class attribute will incorporate `btn-lg` and `btn-block` classes as well.